### PR TITLE
Fix v3 JWE decryption: register CBC-HS content-encryption algorithms

### DIFF
--- a/src/Services/MyinfoBusinessV3/CorppassEncryptedJwtVerifier.php
+++ b/src/Services/MyinfoBusinessV3/CorppassEncryptedJwtVerifier.php
@@ -8,6 +8,11 @@ use Jose\Component\Checker\AlgorithmChecker;
 use Jose\Component\Checker\HeaderCheckerManager;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A128CBCHS256;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A128GCM;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A192CBCHS384;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A192GCM;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A256CBCHS512;
 use Jose\Component\Encryption\Algorithm\ContentEncryption\A256GCM;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHESA128KW;
 use Jose\Component\Encryption\Algorithm\KeyEncryption\ECDHESA192KW;
@@ -59,7 +64,15 @@ class CorppassEncryptedJwtVerifier
     private static function decryptJwe(string $jweToken): string
     {
         $algorithmManager = new AlgorithmManager([
+            // Content encryption: CorpPass uses A256CBC-HS512 for the id_token and
+            // A256GCM for the userinfo JWE; register the GCM and CBC-HS variants.
+            new A128GCM,
+            new A192GCM,
             new A256GCM,
+            new A128CBCHS256,
+            new A192CBCHS384,
+            new A256CBCHS512,
+            // Key management (DPoP-bound ECDH-ES key agreement + AES key wrap).
             new ECDHESA128KW,
             new ECDHESA192KW,
             new ECDHESA256KW,


### PR DESCRIPTION
The CorpPass FAPI 2.0 (MyinfoBusinessV3) flow could not decrypt the id_token.

## Problem
`CorppassEncryptedJwtVerifier::decryptJwe()` registers only `A256GCM` as a content-encryption algorithm. In the live CorpPass **staging** flow:

- the **id_token** JWE uses `enc: A256CBC-HS512`
- the **entity-person userinfo** JWE uses `enc: A256GCM`

So `getAccessToken()` -> `IdTokenValidator::validate()` fails with `RuntimeException: Unable to load and decrypt the token`, surfaced as `InvalidIdTokenException: ID token could not be decrypted or its signature verified`.

Observed id_token JWE header:
```json
{"alg":"ECDH-ES+A256KW","enc":"A256CBC-HS512","cty":"JWT","kid":"enc-...","epk":{...}}
```

## Fix
Register the GCM and CBC-HS content-encryption algorithm variants (`A128/192/256GCM`, `A128CBCHS256`, `A192CBCHS384`, `A256CBCHS512`) in the JWE decrypter `AlgorithmManager`. Verified end-to-end against CorpPass staging: id_token now decrypts/validates and the entity-person userinfo decrypts successfully.